### PR TITLE
Handle unseen vulnerability categories in ML pipeline

### DIFF
--- a/ml_model.py
+++ b/ml_model.py
@@ -1,16 +1,53 @@
-﻿import pandas as pd
-from sklearn.preprocessing import LabelEncoder
-from sklearn.ensemble import RandomForestClassifier
+import warnings
+
 import joblib
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.preprocessing import LabelEncoder
+
+
+def _fit_encoder_with_unknown(values, unknown_token="Unknown"):
+    """Fit a LabelEncoder that can safely encode unseen categories."""
+    encoder = LabelEncoder()
+    encoder.fit(values)
+
+    if unknown_token not in encoder.classes_:
+        encoder.classes_ = np.append(encoder.classes_, unknown_token)
+
+    return encoder
+
+
+def _encode_series(series, encoder, unknown_token="Unknown"):
+    """Encode a categorical series, replacing unseen values with a fallback."""
+    mapping = {label: idx for idx, label in enumerate(encoder.classes_)}
+    encoded = series.map(mapping)
+
+    if encoded.isna().any():
+        warnings.warn(
+            "Encountered categories unknown to the encoder during training; "
+            f"falling back to '{unknown_token}'."
+        )
+        encoded = encoded.fillna(mapping[unknown_token])
+
+    return encoded.astype(int)
+
 
 data = pd.read_csv('ml_data.csv')
 
-le_vuln = LabelEncoder(); data['vuln_type_enc'] = le_vuln.fit_transform(data['vuln_type'])
-le_sev = LabelEncoder(); data['severity_enc'] = le_sev.fit_transform(data['severity'])
-le_user = LabelEncoder(); data['user_input_enc'] = le_user.fit_transform(data['user_input'])
-le_label = LabelEncoder(); data['exploit_enc'] = le_label.fit_transform(data['exploitability'])
+le_vuln = _fit_encoder_with_unknown(data['vuln_type'])
+data['vuln_type_enc'] = _encode_series(data['vuln_type'], le_vuln)
 
-X = data[['vuln_type_enc','severity_enc','user_input_enc']]
+le_sev = _fit_encoder_with_unknown(data['severity'])
+data['severity_enc'] = _encode_series(data['severity'], le_sev)
+
+le_user = _fit_encoder_with_unknown(data['user_input'])
+data['user_input_enc'] = _encode_series(data['user_input'], le_user)
+
+le_label = LabelEncoder()
+data['exploit_enc'] = le_label.fit_transform(data['exploitability'])
+
+X = data[['vuln_type_enc', 'severity_enc', 'user_input_enc']]
 y = data['exploit_enc']
 
 clf = RandomForestClassifier(n_estimators=50, random_state=42)

--- a/predict_exploit.py
+++ b/predict_exploit.py
@@ -1,5 +1,30 @@
-﻿import joblib
+import warnings
+
+import joblib
 import pandas as pd
+
+
+def _safe_encode(values, encoder, unknown_token="Unknown"):
+    mapping = {label: idx for idx, label in enumerate(encoder.classes_)}
+
+    if unknown_token not in mapping:
+        raise ValueError(
+            f"Encoder does not contain the required fallback token '{unknown_token}'."
+        )
+
+    series = pd.Series(values)
+    encoded = series.map(mapping)
+
+    if encoded.isna().any():
+        unknown_values = series[encoded.isna()].unique()
+        warnings.warn(
+            "Encountered categories unknown to the encoder during prediction: "
+            f"{list(unknown_values)}. Falling back to '{unknown_token}'."
+        )
+        encoded = encoded.fillna(mapping[unknown_token])
+
+    return encoded.astype(int)
+
 
 clf = joblib.load('exploit_model.pkl')
 le_vuln = joblib.load('le_vuln.pkl')
@@ -8,17 +33,17 @@ le_user = joblib.load('le_user.pkl')
 le_label = joblib.load('le_label.pkl')
 
 findings = pd.DataFrame([
-    {'vuln_type':'hardcoded_secret','severity':'HIGH','user_input':'No'},
-    {'vuln_type':'eval','severity':'HIGH','user_input':'Yes'},
-    {'vuln_type':'subprocess_call','severity':'HIGH','user_input':'Yes'}
+    {'vuln_type': 'hardcoded_secret', 'severity': 'HIGH', 'user_input': 'No'},
+    {'vuln_type': 'eval', 'severity': 'HIGH', 'user_input': 'Yes'},
+    {'vuln_type': 'subprocess_call', 'severity': 'HIGH', 'user_input': 'Yes'}
 ])
 
-findings['vuln_type_enc'] = le_vuln.transform(findings['vuln_type'])
-findings['severity_enc'] = le_sev.transform(findings['severity'])
-findings['user_input_enc'] = le_user.transform(findings['user_input'])
+findings['vuln_type_enc'] = _safe_encode(findings['vuln_type'], le_vuln)
+findings['severity_enc'] = _safe_encode(findings['severity'], le_sev)
+findings['user_input_enc'] = _safe_encode(findings['user_input'], le_user)
 
-X_pred = findings[['vuln_type_enc','severity_enc','user_input_enc']]
+X_pred = findings[['vuln_type_enc', 'severity_enc', 'user_input_enc']]
 preds_enc = clf.predict(X_pred)
 findings['predicted_exploitability'] = le_label.inverse_transform(preds_enc)
 
-print(findings[['vuln_type','severity','user_input','predicted_exploitability']])
+print(findings[['vuln_type', 'severity', 'user_input', 'predicted_exploitability']])


### PR DESCRIPTION
## Summary
- teach the model training script to append an "Unknown" fallback category when fitting label encoders
- update the prediction script to safely encode incoming findings, warning and falling back when new categories appear

## Testing
- not run (scikit-learn/pandas dependencies unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc9a1d9da48331911613c8e4f224d5